### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ Dealing with hardware is a hassle, and we want a way to communicate with our Ras
 
 If you're a Linux or Mac OS X user, you're in luck, because you can simply use the SSH command! If you're a Windows user, go ahead and download the PuTTY client.  It's free and lightweight!
 
-#####For OS X and Linux users
+##### For OS X and Linux users
 Open up a shell terminal, and type in the following command:
 ```
 ~ $ ssh pi@1.2.3.4
 ```
 Replace ```1.2.3.4``` with the IP address of your Raspberry Pi.  You should be prompted for the password, and after typing it in, you're ready to communicate with your Pi from your personal computer!
 
-#####For Windows users
+##### For Windows users
 Once you have PuTTY downloaded, open it up.  Under the ```Host Name (IP address)``` field, put the IP address of your Pi.  Leave the port as 22, and hit ```Open```. You'll be prompted for both a username and password.  Log in using ```pi``` and ```raspberry```.  You're now ready to send commands to your Pi as well!
 
-#####The Avahi Daemon
+##### The Avahi Daemon
 The Avahi Daemon is a way to connect to your Raspberry Pi via SSH without even having to know the IP address of the Pi.  This makes connecting via SSH far more convenient. Installing the daemon is easy.  Use the following command to install the daemon:
 ```
 pi@raspberrypi ~ $ sudo apt-get install avahi-daemon


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
